### PR TITLE
Refresh planning page once optimize job is over

### DIFF
--- a/app/controllers/daily_quests_controller.rb
+++ b/app/controllers/daily_quests_controller.rb
@@ -50,7 +50,7 @@ class DailyQuestsController < ApplicationController
 
     OptimizerJob.perform_later(steps)
 
-    redirect_to daily_quests_path(started_on: @daily_quest.started_on), notice: "Les missions sont en cours d'assignation. Veuillez patienter, cela peut prendre quelques minutes."
+    head :ok
   end
 
   # @route POST /daily_quests/:id/duplicate_week (duplicate_week_daily_quest)

--- a/app/jobs/optimizer_job.rb
+++ b/app/jobs/optimizer_job.rb
@@ -1,9 +1,46 @@
 class OptimizerJob < ApplicationJob
+  include Rails.application.routes.url_helpers
+
   def perform(step_ids)
     @steps = Step.find(step_ids)
+    daily_quest = @steps.first.mission.daily_quest
 
-    @steps.each do |step|
+    total_steps = @steps.count
+
+    @steps.each_with_index do |step, index|
+      last_one = total_steps == index + 1
+
+      message = <<~MESSAGE
+        Les missions sont en cours d'assignation. Veuillez patienter, cela peut prendre quelques minutes. La page sera automatiquement rafraîchie une fois la tâche accomplie.
+
+        Placement de la mission <strong>#{index + 1}/#{total_steps}</strong>, veuillez patienter...
+      MESSAGE
+
+      if last_one
+        message += <<~MESSAGE
+          La page va être réactualisée dans quelques instants...
+        MESSAGE
+      end
+
+      Turbo::StreamsChannel.broadcast_update_to(
+        :flash,
+        target: 'flash',
+        partial: 'flash',
+        locals: {
+          flash_type: 'notice',
+          message: message
+        }
+      )
+
       Optimizer.call(step)
     end
+
+    # This broadcast is only meant to reload the page once job is completed.
+    Turbo::StreamsChannel.broadcast_append_to(
+      :page_reload,
+      target: 'page_reload',
+      partial: 'page_reload',
+      locals: { url: daily_quests_path(date: daily_quest.started_on) }
+    )
   end
 end

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -1,3 +1,2 @@
-- flash.each do |flash_type, message|
-  .flash__message.p-4.my-4.text-sm.rounded-lg class="#{flash_type == 'notice' ? 'flash-notice ' : 'flash-alert'}"
-    = message
+.flash__message.p-4.my-4.text-sm.rounded-lg class="#{flash_type == 'notice' ? 'flash-notice ' : 'flash-alert'}"
+  == simple_format message

--- a/app/views/application/_flashes.html.slim
+++ b/app/views/application/_flashes.html.slim
@@ -1,0 +1,2 @@
+- flash.each do |flash_type, message|
+  = render 'flash', flash_type: flash_type, message: message

--- a/app/views/application/_page_reload.html.slim
+++ b/app/views/application/_page_reload.html.slim
@@ -1,0 +1,4 @@
+/ This partial is only meant to reload the page once the daily planning
+/ job is completed.
+javascript:
+  Turbo.visit("#{url}")

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -20,6 +20,12 @@ html class=options.theme
   body class="dark:bg-slate-800"
     main.mx-auto.px-5.mb-8 class=('container' unless params[:controller] == 'daily_quests')
       .mb-6= render 'header'
-      #flash= render 'flash'
+
+      = turbo_stream_from :flash
+      #flash= render 'flashes'
 
       = yield
+
+      / Workaround that refresh page after optimze steps job has ended
+      = turbo_stream_from :page_reload
+      #page_reload

--- a/app/views/layouts/session.html.slim
+++ b/app/views/layouts/session.html.slim
@@ -13,6 +13,6 @@ html
 
   body.h-screen
     main.md:w-2/3.lg:w-2/5.mx-auto.p-6
-      #flash= render 'flash'
+      #flash= render 'flashes'
 
       = yield


### PR DESCRIPTION
Broadcast a turbo stream partial that visit planning page url in javascript.  
Update the flash notice each time to reflect the job assignment progress.

<img width="1514" alt="Capture d’écran 2023-10-18 à 17 41 15" src="https://github.com/La-Voix-du-chat-artiste/mobilia/assets/5428510/e980c5a2-985a-4dd8-8c79-debe292b7279">
