### PR TITLE
Mark steps as achieved when time is over

### DIFF
--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -17,6 +17,7 @@ export default class extends Controller {
         animation: 150,
         sort: false,
         handle: '.handle',
+        filter: '.disabled',
         ghost: 'bg-gray-100',
         delayOnTouchOnly: true,
         onEnd: this._assignToNewTransporter.bind(this)

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -194,7 +194,15 @@ class Step < ApplicationRecord
                         target: "mission_step_#{id}"
   end
 
+  def achieved?
+    daily_quest.started_on == Date.current && arrival_at <= Time.current
+  end
+
   private
+
+  def daily_quest
+    mission.daily_quest
+  end
 
   def options
     @options ||= mission.daily_quest.company.setting.options

--- a/app/views/daily_quests/_step.html.slim
+++ b/app/views/daily_quests/_step.html.slim
@@ -1,43 +1,49 @@
-.handle.border.rounded-lg.p-2.mb-2.hover:bg-gray-100.transition-colors.hover:border-green-500.relative.mb-8.dark:bg-slate-700/50.dark:text-white data-step-path=daily_quest_mission_step_path(step.mission.daily_quest, step.mission, step) id=dom_id(step, 'mission') class=colour_for_step(step) class=('animate-pulse' if defined?(pending_placement) && pending_placement)
-  .absolute.-top-7.left-0
-    - if step.customer_to_place?
-      p.mt-1.inline-block.bg-blue-400.text-white.rounded-lg.text-xs.px-2.py-1 Aller
-    - else
-      p.mt-1.inline-block.bg-blue-700.text-white.rounded-lg.text-xs.px-2.py-1 Retour
+details.step.handle.border.rounded-lg.p-2.mb-2.hover:bg-gray-100.transition-colors.hover:border-green-500.relative.mb-8.dark:bg-slate-700/50.dark:text-white.transition-colors data-step-path=daily_quest_mission_step_path(step.mission.daily_quest, step.mission, step) id=dom_id(step, 'mission') class=colour_for_step(step) class=('animate-pulse' if defined?(pending_placement) && pending_placement) class=('disabled opacity-25 hover:opacity-100' if step.achieved?) open=!step.achieved?
+  summary.text-sm class=('cursor-move' unless step.achieved?)
+    .absolute.-top-7.left-0
+      - if step.customer_to_place?
+        p.mt-1.inline-block.bg-blue-400.text-white.rounded-lg.text-xs.px-2.py-1 Aller
+      - else
+        p.mt-1.inline-block.bg-blue-700.text-white.rounded-lg.text-xs.px-2.py-1 Retour
 
-  .cursor-move.mb-3
-    header.flex.items-start.justify-between.mb-2
-      p.font-bold.text-sm= step.title
+    .text-center
+      .flex.items-center.justify-center.gap-2.mb-2
+        p.text-white.p-1.bg-green-500= step.started_at ? l(step.started_at.round, format: '%Hh%M') : "XXX"
+        | >>
+        p.text-white.p-1.bg-green-500= step.arrival_at ? l(step.arrival_at.round, format: '%Hh%M') : "XXX"
+      span.font-bold= step.title
 
       - if step.single?
-        = link_to 'Placer', optimize_daily_quest_step_path(step.mission.daily_quest, step), class: 'inline-block btn-add !p-1', data: { turbo_method: :post, turbo_confirm: 'Voulez-vous placer automatiquement cette mission ?' }
+        p.text-center.my-2
+          = link_to 'Placer', optimize_daily_quest_step_path(step.mission.daily_quest, step), class: 'inline-block btn-add !p-1', data: { turbo_method: :post, turbo_confirm: 'Voulez-vous placer automatiquement cette mission ?' }
 
-    hr.border.border-gray-300.mb-2.dark:border-gray-700
+  hr.border.border-gray-300.my-3.dark:border-gray-700
 
-    div
-      .flex.items-center.gap-2.mb-2
-        p.text-white.p-1.bg-green-500= step.started_at ? l(step.started_at.round, format: '%Hh%M') : "XXX"
+  div
+    .flex.items-center.gap-2.mb-2
+      p.text-white.p-1.bg-green-500= step.started_at ? l(step.started_at.round, format: '%Hh%M') : "XXX"
 
-        div
-          p.text-xs.text-gray-400= step.departure_address.label
+      div
+        p.text-xs.text-gray-400= step.departure_address.label
 
-    <svg class="w-3 h-3 mt-1 mb-2 mx-auto text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 12">
-      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 7 4 4 4-4M1 1l4 4 4-4"/>
-    </svg>
+  <svg class="w-3 h-3 mt-1 mb-2 mx-auto text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 12">
+    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 7 4 4 4-4M1 1l4 4 4-4"/>
+  </svg>
 
-    .mb-3
-      .flex.items-center.gap-2.mb-2
-        p.text-white.p-1.bg-green-500= step.arrival_at ? l(step.arrival_at.round, format: '%Hh%M') : "XXX"
+  .mb-3
+    .flex.items-center.gap-2.mb-2
+      p.text-white.p-1.bg-green-500= step.arrival_at ? l(step.arrival_at.round, format: '%Hh%M') : "XXX"
 
-        div
-          p.text-xs.text-gray-400= step.arrival_address.label
+      div
+        p.text-xs.text-gray-400= step.arrival_address.label
 
-    p.row.px-2.py-1.text-xs.mb-3
-      span= distance_of_time_in_words(step.duration * 60)
-      |>< /
-      span= number_to_human(step.distance * 1_000, units: :distance)
+  p.row.px-2.py-1.text-xs.mb-3
+    span= distance_of_time_in_words(step.duration * 60)
+    |>< /
+    span= number_to_human(step.distance * 1_000, units: :distance)
 
-    = simple_form_for [step.mission.daily_quest, step.mission, step] do |f|
+  - unless step.achieved?
+    = simple_form_for [step.mission.daily_quest, step.mission, step], html: { class: 'mb-3' } do |f|
       - scope = Transporter.with_attached_photo.includes(:absences, :address).reject { |t| t.off?(step.mission.daily_quest.started_on) }
       = f.association :transporter,
                       collection: transporters_select_options(scope),
@@ -54,8 +60,11 @@
                       label_html: { class: 'text-sm' },
                       wrapper_html: { class: 'w-full' }
 
-  = turbo_frame_tag dom_id(step) do
-    = link_to 'Ajouter une remarque', edit_daily_quest_step_path(step.mission.daily_quest, step), class: 'underline text-sm'
+  - if step.achieved?
+    .panel-success class="!text-xs" Mission terminée 🎉 (déterminé algorithmiquement)
+  - else
+    = turbo_frame_tag dom_id(step) do
+      = link_to 'Ajouter une remarque', edit_daily_quest_step_path(step.mission.daily_quest, step), class: 'underline text-sm'
 
   - if step.conflict?
     p.mt-1.p-1.bg-orange-500.rounded-lg.text-xs.text-white

--- a/app/views/daily_quests/index.html.slim
+++ b/app/views/daily_quests/index.html.slim
@@ -94,14 +94,9 @@ details.panel-info.mb-5
       .panel-success
         p Félicitations, vous avez assigné toutes les missions en attente !
     - else
-      .clear-both.py-1
       .sortable_steps.grid.grid-cols-1.md:grid-cols-2.lg:grid-cols-3.xl:grid-cols-5.gap-3.pt-3 class="min-h-[300px]" id="backlog"
         - steps.includes(:transporter, mission: :daily_quest).each do |step|
           = render 'step', step: step
-
-
-
-
 
 
   .flex.flex-col.lg:flex-row.justify-between.gap-3.flex-nowrap.overflow-x-auto


### PR DESCRIPTION
Add an opacity to highlight that a step is now considered as achieved when it's time is considered as over algorithmically speaking.

Replace the step markup with a `details`/`summary` tags to close achieved steps by default and earn some page height.

<img width="781" alt="Capture d’écran 2023-10-18 à 18 57 37" src="https://github.com/La-Voix-du-chat-artiste/mobilia/assets/5428510/0e323308-49a5-46cf-a28c-5da6fe884519">
