### PR TITLE
Update dialog confirm popup with a prettier Tailwind style

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,3 +5,17 @@ import "trix"
 import "@rails/actiontext"
 
 import * as L from 'leaflet'
+
+// @see https://gorails.com/episodes/custom-hotwire-turbo-confirm-modals
+Turbo.setConfirmMethod((message, element) => {
+  let dialog = document.getElementById('turbo-confirm')
+
+  dialog.querySelector('p').textContent = message
+  dialog.showModal()
+
+  return new Promise((resolve, reject) => {
+    dialog.addEventListener('close', () => {
+      resolve(dialog.returnValue == 'confirm')
+    }, { once: true })
+  })
+})

--- a/app/views/application/_turbo_confirm.html.slim
+++ b/app/views/application/_turbo_confirm.html.slim
@@ -1,0 +1,20 @@
+dialog#turbo-confirm.bg-white.rounded-lg.shadow.fixed.dark:bg-gray-700.dark:text-white
+  form#popup-modal.relative.w-full.max-w-md method="dialog" tabindex="-1"
+    button value="cancel" class="absolute top-3 right-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ml-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white"
+      <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+      </svg>
+      span.sr-only Fermer la modale
+
+    .p-6.text-center
+      <svg class="mx-auto mb-4 text-gray-400 w-12 h-12" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 11V6m0 8h.01M19 10a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+      </svg>
+
+      p.mb-5.text-lg.font-normal.text-gray-500.dark:text-white Êtes-vous sûr ?
+
+      button value="cancel" class="text-gray-500 bg-white hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-200 rounded-lg border border-gray-200 text-sm font-medium px-5 py-2.5 hover:text-gray-900 focus:z-10 mr-2 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-500 dark:hover:text-white dark:hover:bg-gray-600"
+        | Annuler
+
+      button value="confirm" class="text-white bg-red-600 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm inline-flex items-center px-5 py-2.5 text-center"
+        | Confirmer

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -29,3 +29,5 @@ html class=options.theme
       / Workaround that refresh page after optimze steps job has ended
       = turbo_stream_from :page_reload
       #page_reload
+
+      = render 'turbo_confirm'


### PR DESCRIPTION
Refactoring the browser confirm modal following the great tutorial from [gorails](https://gorails.com/episodes/custom-hotwire-turbo-confirm-modals).

<img width="546" alt="Capture d’écran 2023-10-23 à 14 12 18" src="https://github.com/La-Voix-du-chat-artiste/mobilia/assets/5428510/d6ff3491-52b7-41ab-8b25-67196f56fe4c">
