### PR TITLE
Batch of enhancements

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -206,3 +206,13 @@ input.boolean, input.check_boxes {
 .flash-alert {
   @apply border text-red-500 bg-red-50 border-red-500 p-2 rounded-lg text-sm dark:bg-gray-800 dark:text-red-400;
 }
+
+/* Progress bar */
+
+.progress {
+  @apply w-full bg-gray-600 rounded-full mt-3;
+}
+
+.progress .progress-label {
+  @apply bg-green-600 text-xs font-medium text-white text-center p-1 leading-none rounded-full;
+}

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -193,6 +193,10 @@ input.boolean, input.check_boxes {
   @apply border text-green-500 bg-green-50 border-green-500 p-2 rounded-lg text-sm dark:bg-gray-800 dark:text-green-400;
 }
 
+.panel-error {
+  @apply border text-red-500 bg-red-50 border-red-500 p-2 rounded-lg text-sm dark:bg-gray-800 dark:text-red-400;
+}
+
 .row {
   @apply border mb-3 rounded-lg border-gray-300 bg-gray-100 dark:bg-slate-700/50 dark:text-white dark:border-gray-600;
 }

--- a/app/controllers/daily_quests_controller.rb
+++ b/app/controllers/daily_quests_controller.rb
@@ -1,5 +1,7 @@
 class DailyQuestsController < ApplicationController
-  before_action :set_daily_quest, only: %i[show edit update destroy optimize duplicate_week]
+  before_action :set_daily_quest, only: %i[
+    show edit update destroy optimize duplicate_week reset
+  ]
 
   # @route GET /daily_quests (daily_quests)
   def index
@@ -58,6 +60,13 @@ class DailyQuestsController < ApplicationController
     DuplicateWeekJob.perform_later(@daily_quest)
 
     redirect_to daily_quests_path(date: @daily_quest.started_on), notice: 'La semaine est en cours de duplication. Veuillez patienter, cela peut prendre quelques minutes.'
+  end
+
+  # @route POST /daily_quests/:id/reset (reset_daily_quest)
+  def reset
+    ResetDailyQuest.call(@daily_quest)
+
+    redirect_to daily_quests_path(date: @daily_quest.started_on), notice: 'Le planning du jour a bien été réinitialisé'
   end
 
   private

--- a/app/controllers/daily_quests_controller.rb
+++ b/app/controllers/daily_quests_controller.rb
@@ -1,10 +1,15 @@
 class DailyQuestsController < ApplicationController
+  MAX_HOUR = 18
+
   before_action :set_daily_quest, only: %i[
     show edit update destroy optimize duplicate_week reset
   ]
 
   # @route GET /daily_quests (daily_quests)
   def index
+    # Planning redirect to tomorrow if todays missions are ended
+    redirect_to daily_quests_path(date: Date.tomorrow) if params[:date].blank? && Time.current.hour >= MAX_HOUR
+
     @daily_quest = company.daily_quests.find_or_create_by(started_on: date)
     @transporters = company.transporters.all.with_attached_photo.includes(:absences).sort_by_courses_for(@daily_quest)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -99,9 +99,9 @@ module ApplicationHelper
 
   def colour_for_step(step)
     if step.conflict?
-      'border-2 border-orange-300'
+      'border-2 border-orange-300 dark:border-orange-600'
     elsif step.impossible?
-      'border-2 border-red-300'
+      'border-2 border-red-300 dark:border-red-600'
     elsif step.customer_to_place?
       'border-2 border-blue-400'
     else

--- a/app/javascript/controllers/global_map_controller.js
+++ b/app/javascript/controllers/global_map_controller.js
@@ -41,7 +41,7 @@ export default class extends ApplicationController {
     }
 
     this.map = L.map(this.mapTarget, {
-      gestureHandling: true,
+      gestureHandling: false,
       attributionControl: false,
       zoomControl: false
     })

--- a/app/javascript/controllers/global_map_controller.js
+++ b/app/javascript/controllers/global_map_controller.js
@@ -1,5 +1,6 @@
 import { ApplicationController, useIntersection } from 'stimulus-use'
 import { get } from '@rails/request.js'
+import 'leaflet.markercluster'
 import 'leaflet-gesture-handling'
 
 export default class extends ApplicationController {
@@ -52,7 +53,9 @@ export default class extends ApplicationController {
 
     const tuiles = L.tileLayer("https://a.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png").addTo(this.map)
 
-    this.markers = new L.FeatureGroup()
+    this.markers = L.markerClusterGroup({
+      showCoverageOnHover: false, maxClusterRadius: 20
+    })
 
     this.customers.forEach((customer) => {
       let marker

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ eagerLoadControllersFrom("controllers", application)
 // Lazy load controllers as they appear in the DOM (remember not to preload controllers in import map!)
 // import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
 // lazyLoadControllersFrom("controllers", application)
+
+import PasswordVisibility from 'stimulus-password-visibility'
+application.register('password-visibility', PasswordVisibility)

--- a/app/javascript/controllers/mission_map_controller.js
+++ b/app/javascript/controllers/mission_map_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
 
   connect() {
     this.map = L.map(this.element, {
-      gestureHandling: true,
+      gestureHandling: false,
       attributionControl: false
     })
 

--- a/app/jobs/optimizer_job.rb
+++ b/app/jobs/optimizer_job.rb
@@ -7,24 +7,32 @@ class OptimizerJob < ApplicationJob
 
     total_steps = @steps.count
 
-    @steps.each_with_index do |step, index|
-      last_one = total_steps == index + 1
+    @steps.each.with_index(1) do |step, index|
+      last_one = total_steps == index
+      percentage = (index / total_steps.to_f) * 100
 
-      message = <<~MESSAGE
+      message = <<~MESSAGE.squish
         Les missions sont en cours d'assignation. Veuillez patienter, cela peut prendre quelques minutes. La page sera automatiquement rafraîchie une fois la tâche accomplie.
 
-        Placement de la mission <strong>#{index + 1}/#{total_steps}</strong>, veuillez patienter...
+        <br />
+
+        Placement de la mission <strong>#{index}/#{total_steps}</strong>, veuillez patienter...
+
+        <div class="progress">
+          <div class="progress-label" style="width: #{percentage.to_i}%">#{percentage.to_i}%</div>
+        </div>
       MESSAGE
 
       if last_one
         message += <<~MESSAGE
+
           La page va être réactualisée dans quelques instants...
         MESSAGE
       end
 
       Turbo::StreamsChannel.broadcast_update_to(
         :flash,
-        target: 'flash',
+        target: 'flashes',
         partial: 'flash',
         locals: {
           flash_type: 'notice',

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,4 +4,18 @@ class ApplicationRecord < ActiveRecord::Base
   def self.human_enum_name(enum_name, enum_value, locale: I18n.locale)
     I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}", locale: locale)
   end
+
+  # :nocov:
+  def self.broadcast_flash(type, message)
+    Turbo::StreamsChannel.broadcast_prepend_to(
+      :flash,
+      target: 'flashes',
+      partial: 'flash',
+      locals: {
+        flash_type: type.to_s,
+        message: message
+      }
+    )
+  end
+  # :nocov:
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -7,10 +7,12 @@ class Step < ApplicationRecord
     customer_to_place: 1,
     place_to_customer: 2,
     customer_to_transporter: 3,
-    customer_to_customer: 4,
-    conflict: 5,
-    possible: 6,
-    impossible: 7
+    customer_to_customer: 4
+  }
+  enum status: {
+    possible: 0,
+    conflict: 1,
+    impossible: 2
   }
   enum departure_point_icon: {
     starting_line: 0, transporter: 1, customer: 2, place: 3, ending_line: 4
@@ -226,6 +228,7 @@ end
 #  mission_id           :bigint(8)        not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  status               :integer          default("possible"), not null
 #
 # Indexes
 #

--- a/app/services/optimizer.rb
+++ b/app/services/optimizer.rb
@@ -71,7 +71,7 @@ class Optimizer < ApplicationService
     best = best_transporters.min_by { |x, y| x.second <=> y.second } if best_transporters.present?
 
     step.transporter_id = best&.first
-    step.role = step.transporter_id.blank? ? :conflict : :possible
+    step.status = step.transporter_id.blank? ? :conflict : :possible
     step.save!
 
     step.broadcast_remove_from_unassigned_bucket

--- a/app/services/reset_daily_quest.rb
+++ b/app/services/reset_daily_quest.rb
@@ -1,0 +1,9 @@
+class ResetDailyQuest < ApplicationService
+  def initialize(daily_quest)
+    @daily_quest = daily_quest
+  end
+
+  def call
+    @daily_quest.steps.update_all(transporter_id: nil)
+  end
+end

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -1,2 +1,2 @@
 .flash__message.p-4.my-4.text-sm.rounded-lg class="#{flash_type == 'notice' ? 'flash-notice ' : 'flash-alert'}"
-  == simple_format message
+  == simple_format message, {}, { sanitize_options: { attributes: %w[class style] } }

--- a/app/views/daily_quests/_mission_fields.html.slim
+++ b/app/views/daily_quests/_mission_fields.html.slim
@@ -33,7 +33,7 @@
               }, \
               wrapper_html: { class: 'w-full' }
 
-    = f.input :drop_duration, input_html: { value: 30 },
+    = f.input :drop_duration,
               wrapper_html: { class: 'w-full' }
 
   .absolute.-right-2.-top-0

--- a/app/views/daily_quests/_step.html.slim
+++ b/app/views/daily_quests/_step.html.slim
@@ -16,16 +16,16 @@
     summary.text-sm class=(step.achieved? ? 'cursor-pointer' : 'cursor-move')
       .text-center
         .flex.items-center.justify-center.gap-2.mb-2
-          p.text-white.p-1.bg-green-500= step.started_at ? l(step.started_at.round, format: '%Hh%M') : "XXX"
+          p.panel-success= step.started_at ? l(step.started_at.round, format: '%Hh%M') : "XXX"
           | >>
-          p.text-white.p-1.bg-green-500= step.arrival_at ? l(step.arrival_at.round, format: '%Hh%M') : "XXX"
+          p.panel-success= step.arrival_at ? l(step.arrival_at.round, format: '%Hh%M') : "XXX"
         span.font-bold= step.title
 
     hr.border.border-gray-300.my-3.dark:border-gray-700
 
     .space-y-3.mb-3
       .flex.items-center.gap-2
-        p.text-white.p-1.bg-green-500= step.started_at ? l(step.started_at.round, format: '%Hh%M') : "XXX"
+        p.panel-success= step.started_at ? l(step.started_at.round, format: '%Hh%M') : "XXX"
 
         div
           p.text-xs.text-gray-400= step.departure_address.label
@@ -45,7 +45,7 @@
         </svg>
 
       .flex.items-center.gap-2.mb-2
-        p.text-white.p-1.bg-green-500= step.arrival_at ? l(step.arrival_at.round, format: '%Hh%M') : "XXX"
+        p.panel-success= step.arrival_at ? l(step.arrival_at.round, format: '%Hh%M') : "XXX"
 
         div
           p.text-xs.text-gray-400= step.arrival_address.label

--- a/app/views/daily_quests/_step.html.slim
+++ b/app/views/daily_quests/_step.html.slim
@@ -1,11 +1,14 @@
 - daily_quest = step.mission.daily_quest
 
-.step.handle.border.rounded-lg.p-2.hover:bg-gray-100.transition-colors.hover:border-green-500.relative.dark:bg-slate-700/50.dark:text-white.transition-colors data-step-path=daily_quest_mission_step_path(daily_quest, step.mission, step) id=dom_id(step, 'mission') class=colour_for_step(step) class=('animate-pulse' if defined?(pending_placement) && pending_placement) class=('opacity-25 hover:opacity-100' if step.achieved?)
+.step.handle.border.rounded-lg.p-2.hover:bg-gray-100.transition-all.hover:border-green-500.relative.dark:bg-slate-700/50.dark:text-white data-step-path=daily_quest_mission_step_path(daily_quest, step.mission, step) id=dom_id(step, 'mission') class=colour_for_step(step) class=('animate-pulse' if defined?(pending_placement) && pending_placement) class=('opacity-25 hover:opacity-100' if step.achieved?)
   header.flex.items-start.justify-between.mb-2
     - if step.customer_to_place?
       p.bg-blue-400.text-white.rounded-lg.text-xs.px-2.py-1 Aller
-    - else
+    - elsif step.place_to_customer?
       p.bg-blue-700.text-white.rounded-lg.text-xs.px-2.py-1 Retour
+    - else
+      p.mt-1.inline-block.bg-gray-700.text-white.rounded-lg.text-xs.px-2.py-1
+        = step.role
 
     = render 'daily_quests/step_menu', step: step
 
@@ -72,8 +75,8 @@
         = link_to 'Ajouter une remarque', edit_daily_quest_step_path(step.mission.daily_quest, step), class: 'underline text-sm'
 
     - if step.conflict?
-      p.mt-1.p-1.bg-orange-500.rounded-lg.text-xs.text-white
+      p.mt-2.text-center.panel-warning
         | ⚠️ Trajet en conflit
     - elsif step.impossible?
-      p.mt-1.p-1.bg-red-500.rounded-lg.text-xs.text-white
+      p.mt-2.text-center.panel-error
         | ⚠️ Trajet impossible

--- a/app/views/daily_quests/_transporter_missions.html.slim
+++ b/app/views/daily_quests/_transporter_missions.html.slim
@@ -1,0 +1,2 @@
+- daily_quest.steps.includes(:transporter, mission: :daily_quest).where(transporter: transporter).each do |step|
+  = render 'daily_quests/step', step: step

--- a/app/views/daily_quests/index.html.slim
+++ b/app/views/daily_quests/index.html.slim
@@ -99,13 +99,12 @@ details.panel-info.mb-3
     - steps = @daily_quest.steps.single
 
     - if steps.empty?
-      .panel-success
+      .panel-success.mt-2
         p Félicitations, vous avez assigné toutes les missions en attente !
-    - else
-      .sortable_steps.grid.grid-cols-1.md:grid-cols-2.lg:grid-cols-3.xl:grid-cols-5.gap-3.pt-3 class="min-h-[300px]" id="backlog"
-        - steps.includes(:transporter, mission: :daily_quest).each do |step|
-          = render 'step', step: step
 
+    .sortable_steps.grid.grid-cols-1.md:grid-cols-2.lg:grid-cols-3.xl:grid-cols-5.gap-3.mt-2 class="min-h-[300px]" id="backlog"
+      - steps.includes(:transporter, mission: :daily_quest).each do |step|
+        = render 'step', step: step
 
   .flex.flex-col.lg:flex-row.justify-between.gap-3.flex-nowrap.overflow-x-auto
     - transporters_count = 0

--- a/app/views/daily_quests/index.html.slim
+++ b/app/views/daily_quests/index.html.slim
@@ -5,16 +5,29 @@ header.mb-3
     h1.text-3xl Missions #{l(@daily_quest.started_on, format: :complete_slash)}
 
     .flex.flex-row.items-center.gap-2
-      = link_to 'Dupliquer toute la semaine',
-                '#',
-                title: 'Feature coming soon',
-                class: 'btn-add cursor-not-allowed line-through',
-                data: { turbo_method: :post, turbo_confirm: "[Coming soon] Voulez-vous dupliquer la semaine du #{l(@daily_quest.started_on.beginning_of_week)} - #{l(@daily_quest.started_on.end_of_week)} sur la semaine du #{l(@daily_quest.started_on.beginning_of_week + 1.week)} - #{l(@daily_quest.started_on.end_of_week + 1.week)} ? Si une des journées existe déjà, elle sera supprimée et remplacée par la journée correspondante de la semaine sélectionnée" }
-
       = link_to "<< #{l(@daily_quest.started_on - 1.day)}", daily_quests_path(date: @daily_quest.started_on - 1.day), class: 'btn-back'
+
+      .group.relative.z-50 tabindex="-1"
+        button.inline-flex.w-full.items-center.justify-center.font-medium.leading-5.focus-within:outline.focus-within:outline-2.focus-within:border-transparent.focus-within:outline-primary-color.btn-add[type="button" aria-haspopup="true"]
+          span Menu
+          svg.ml-2.-mr-1.h-5.w-5[viewbox="0 0 20 20" fill="currentColor"]
+            path[fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"]
+
+        .invisible.origin-top-right.-translate-y-2.scale-95.transform.opacity-0.transition-all.duration-300.group-focus-within:visible.group-focus-within:translate-y-0.group-focus-within:scale-100.group-focus-within:opacity-100
+          .absolute.right-0.mt-2.w-56.origin-top-right.divide-y.divide-gray-100.rounded-md.border.border-gray-200.bg-white.shadow-lg.outline-none.dark:bg-gray-700.dark:border-gray-600.dark:text-white role="menu"
+            nav.flex.flex-col.divide-y.dark:divide-gray-600.text-sm
+              = link_to 'Détails des missions', @daily_quest, class: 'p-3 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors'
+              - if @daily_quest.started_on >= Date.current
+                = link_to 'Ajouter/Modifier une mission', edit_daily_quest_path(@daily_quest), class: 'p-3 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors'
+                - if @daily_quest.steps.any?(&:transporter)
+                  = link_to 'Envoyer les plannings de tous les chauffeurs par email', send_all_plannings_daily_quest_transporters_path(@daily_quest), data: { turbo_method: :post, turbo_confirm: 'Voulez-vous envoyer les plannings du jour à tous les chauffeurs par email ?' }, class: 'p-3 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors'
+              = link_to 'Dupliquer toute la semaine',
+                        duplicate_week_daily_quest_path(@daily_quest), class: 'p-3 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors',
+                        data: { turbo_method: :post, turbo_confirm: "Voulez-vous dupliquer la semaine du #{l(@daily_quest.started_on.beginning_of_week)} - #{l(@daily_quest.started_on.end_of_week)} sur la semaine du #{l(@daily_quest.started_on.beginning_of_week + 1.week)} - #{l(@daily_quest.started_on.end_of_week + 1.week)} ? Si une des journées existe déjà, elle sera supprimée et remplacée par la journée correspondante de la semaine sélectionnée" }
+
       = link_to "#{l(@daily_quest.started_on + 1.day)} >>", daily_quests_path(date: @daily_quest.started_on + 1.day), class: 'btn-back'
 
-details.panel-info.mb-5
+details.panel-info.mb-3
   summary.cursor-pointer Explications à lire
 
   .mt-2
@@ -35,18 +48,6 @@ details.panel-info.mb-5
       li Vous pouvez toujours réaffecter des missions placées automatiquement par l'algorithme manuellement si des changements sont nécessaires. Un code couleur avertira d'un potentiel conflit de durée ou de distance.
       li Renseigner de manière la plus précise possible les informations du véhicule, les absences des chauffeurs, les informations complémentaires des clients et des lieux permet à l'algorithme de créer un planning précis et de générer moins de stress pour les chauffeurs.
       li Chaque chauffeur a automatiquement un PDF contenant toutes les missions de sa journée avec toutes les informations nécessaires intégrées dessus.
-
-
-.flex.flex-col.md:flex-row.items-center.justify-center.lg:justify-end.gap-2.mb-3
-  = link_to 'Détails des missions', @daily_quest, class: 'btn-show'
-  - if @daily_quest.started_on >= Date.current
-    = link_to 'Ajouter une mission', edit_daily_quest_path(@daily_quest), class: 'btn-add'
-    = link_to send_all_plannings_daily_quest_transporters_path(@daily_quest), data: { turbo_method: :post, turbo_confirm: 'Voulez-vous envoyer les plannings du jour à tous les chauffeurs par email ?' }, class: 'btn-edit' do
-      <svg class="w-6 h-6 text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 16">
-        <path d="m10.036 8.278 9.258-7.79A1.979 1.979 0 0 0 18 0H2A1.987 1.987 0 0 0 .641.541l9.395 7.737Z"/>
-        <path d="M11.241 9.817c-.36.275-.801.425-1.255.427-.428 0-.845-.138-1.187-.395L0 2.6V14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V2.5l-8.759 7.317Z"/>
-      </svg>
-      p.ml-3 Envoyer les plannings de tous les chauffeurs
 
 - if @transporters.any?(&:no_vehicle?)
   .panel-warning.mb-3

--- a/app/views/daily_quests/index.html.slim
+++ b/app/views/daily_quests/index.html.slim
@@ -148,5 +148,4 @@ details.panel-info.mb-3
             </svg>
 
         .sortable_steps.space-y-2 class="min-h-[300px]" data-transporter-id=transporter.id id=dom_id(transporter, 'mission')
-          - @daily_quest.steps.includes(:transporter, mission: :daily_quest).where(transporter: transporter).each do |step|
-            = render 'step', step: step
+          = render 'transporter_missions', daily_quest: @daily_quest, transporter: transporter

--- a/app/views/daily_quests/index.html.slim
+++ b/app/views/daily_quests/index.html.slim
@@ -24,6 +24,11 @@ header.mb-3
               = link_to 'Dupliquer toute la semaine',
                         duplicate_week_daily_quest_path(@daily_quest), class: 'p-3 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors',
                         data: { turbo_method: :post, turbo_confirm: "Voulez-vous dupliquer la semaine du #{l(@daily_quest.started_on.beginning_of_week)} - #{l(@daily_quest.started_on.end_of_week)} sur la semaine du #{l(@daily_quest.started_on.beginning_of_week + 1.week)} - #{l(@daily_quest.started_on.end_of_week + 1.week)} ? Si une des journées existe déjà, elle sera supprimée et remplacée par la journée correspondante de la semaine sélectionnée" }
+              - if @daily_quest.steps.any?(&:transporter)
+                = link_to 'Réinitialiser le planning',
+                          reset_daily_quest_path(@daily_quest),
+                          data: { turbo_method: :post, turbo_confirm: 'Voulez-vous réinitialiser le planning du jour ? Toutes les missions se trouvant actuellement dans les colonnes des chauffeurs seront désassignées.' },
+                          class: 'p-3 text-red-700 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors'
 
       = link_to "#{l(@daily_quest.started_on + 1.day)} >>", daily_quests_path(date: @daily_quest.started_on + 1.day), class: 'btn-back'
 

--- a/app/views/daily_quests/missions/steps/update.turbo_stream.slim
+++ b/app/views/daily_quests/missions/steps/update.turbo_stream.slim
@@ -4,5 +4,5 @@
     = render 'daily_quests/step', step: @step
 - else
   = turbo_stream.remove dom_id(@step, 'mission')
-  = turbo_stream.prepend dom_id(@step.transporter, 'mission') do
-    = render 'daily_quests/step', step: @step
+  = turbo_stream.update dom_id(@step.transporter, 'mission') do
+    = render 'daily_quests/transporter_missions', daily_quest: @step.mission.daily_quest, transporter: @step.transporter

--- a/app/views/homes/show.html.slim
+++ b/app/views/homes/show.html.slim
@@ -1,15 +1,13 @@
 div data-controller="global-map" data-global-map-customers-url-value=daily_customers_path(date: params[:date]) data-global-map-places-url-value=daily_places_path(date: params[:date]) data-global-map-transporters-url-value=daily_transporters_path(date: params[:date]) data-global-map-refresh-transporters-value=@refresh.to_s data-global-map-refresh-transporters-delay-value=(@refresh_map_interval.seconds.to_i * 1000 if @refresh) data-global-map-latitude-value=company.setting.address&.latitude data-global-map-longitude-value=company.setting.address&.longitude
   #map.w-screen.h-screen.absolute.inset-0 data-global-map-target="map"
 
-  section.absolute.bottom-8.left-2.text-xs.bg-white/75.p-2.border.rounded-lg.z-20
+  section.absolute.bottom-8.left-2.text-xs.bg-white/75.p-2.border.rounded-lg.z-20.dark:bg-gray-700.dark:text-white
     - date = params[:date] ? params[:date].to_date : Date.current
 
     .mb-1
-      p.border-b.mb-2.bg-gray-600.px-2.rounded-lg.text-white.text-xs.text-center class="py-0.5" Planning <strong>#{l(date, format: :complete_slash)}</strong>
+      p.mb-2.bg-gray-600.px-2.rounded-lg.text-white.text-xs.text-center.dark:border-gray-200 class="py-0.5" Planning <strong>#{l(date, format: :complete_slash)}</strong>
 
     .mb-3
-      / p.font-bold.mb-2 Légende
-
       p.flex.items-center.gap-2.mb-2.cursor-pointer data-action="click->global-map#toggleCustomers"
         span.inline-block.w-6.h-6.border-2.border-white.bg-green-500.rounded-full
         span< Clients
@@ -24,8 +22,8 @@ div data-controller="global-map" data-global-map-customers-url-value=daily_custo
 
     div
       - if params[:date].blank? || Date.current == params[:date]&.to_date
-        = link_to "Voir demain (#{l(date.tomorrow, format: :complete_slash)}) >>", root_path(date: Date.tomorrow), class: 'border rounded-lg px-2 py-0.5 bg-gray-100'
+        = link_to "Voir demain (#{l(date.tomorrow, format: :complete_slash)}) >>", root_path(date: Date.tomorrow), class: 'rounded-lg px-2 py-0.5 bg-gray-100 dark:bg-gray-500 dark:text-white'
       - else
-        = link_to "<< Voir aujourd'hui (#{l(date.yesterday, format: :complete_slash)})", root_path, class: 'border rounded-lg px-2 py-0.5 bg-gray-100'
+        = link_to "<< Voir aujourd'hui (#{l(date.yesterday, format: :complete_slash)})", root_path, class: 'rounded-lg px-2 py-0.5 bg-gray-100 dark:bg-gray-500 dark:text-white'
 
 = turbo_frame_tag :marker_details, class: 'absolute right-0 bottom-0 lg:bottom-20 lg:max-w-[350px] z-20'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -22,7 +22,7 @@ html class=options.theme
       .mb-6= render 'header'
 
       = turbo_stream_from :flash
-      #flash= render 'flashes'
+      #flashes= render 'flashes'
 
       = yield
 

--- a/app/views/layouts/session.html.slim
+++ b/app/views/layouts/session.html.slim
@@ -13,6 +13,6 @@ html
 
   body.h-screen
     main.md:w-2/3.lg:w-2/5.mx-auto.p-6
-      #flash= render 'flashes'
+      #flashes= render 'flashes'
 
       = yield

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -8,12 +8,28 @@
               wrapper_html: { class: 'mb-5' },
               autofocus: true,
               placeholder: 'admin1@test.test',
-              hint: 'Use admin1@test.test for demo purposes'
+              hint: 'Use <strong>admin1@test.test</strong> for demo purposes'.html_safe
 
-    = f.input :password, as: :password,
-              wrapper_html: { class: 'mb-5' },
-              placeholder: 'password',
-              hint: 'Use password for demo purposes'
+    .relative data-controller="password-visibility"
+      = f.input :password,
+                as: :password,
+                wrapper_html: { class: 'mb-5' },
+                input_html: { \
+                  data: { password_visibility_target: 'input' } \
+                },
+                placeholder: 'password',
+                hint: 'Use <strong>password</strong> for demo purposes'.html_safe
+
+      button.absolute.h-6.w-6.right-3 class="top-10" type="button" data-action="password-visibility#toggle"
+        p data-tooltip="Afficher le mot de passe en clair"
+          svg.w-6.h-6.text-gray-600 data-password-visibility-target="icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 14"
+            g stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              path d="M10 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"
+              path d="M10 13c4.97 0 9-2.686 9-6s-4.03-6-9-6-9 2.686-9 6 4.03 6 9 6Z"
+
+        p data-tooltip="Masquer le mot de passe"
+          svg.w-6.h-6.text-gray-600 data-password-visibility-target="icon" class="hidden" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 18"
+            path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1.933 10.909A4.357 4.357 0 0 1 1 9c0-1 4-6 9-6m7.6 3.8A5.068 5.068 0 0 1 19 9c0 1-3 6-9 6-.314 0-.62-.014-.918-.04M2 17 18 1m-5 8a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
 
     = f.input :remember, as: :boolean,
               wrapper_html: { class: 'mb-5' }

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -13,6 +13,7 @@ pin 'slim-select', to: 'https://ga.jspm.io/npm:slim-select@2.6.0/dist/slimselect
 pin 'sortablejs', to: 'https://ga.jspm.io/npm:sortablejs@1.15.0/modular/sortable.esm.js'
 
 pin 'stimulus-use', to: 'https://ga.jspm.io/npm:stimulus-use@0.52.0/dist/index.js'
+pin 'stimulus-password-visibility', to: 'https://ga.jspm.io/npm:stimulus-password-visibility@2.1.1/dist/stimulus-password-visibility.mjs'
 
 pin 'leaflet', to: 'https://ga.jspm.io/npm:leaflet@1.9.2/dist/leaflet-src.js'
 pin 'leaflet.markercluster', to: 'https://ga.jspm.io/npm:leaflet.markercluster@1.5.3/dist/leaflet.markercluster-src.js'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
 
   resources :daily_quests do
     member do
+      post :reset
       post :duplicate_week
       post 'optimize'
     end

--- a/db/migrate/20231025181835_add_status_to_step.rb
+++ b/db/migrate/20231025181835_add_status_to_step.rb
@@ -1,0 +1,5 @@
+class AddStatusToStep < ActiveRecord::Migration[7.1]
+  def change
+    add_column :steps, :status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_16_203309) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_25_181835) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -157,6 +157,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_16_203309) do
     t.bigint "mission_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0, null: false
     t.index ["mission_id"], name: "index_steps_on_mission_id"
     t.index ["transporter_id"], name: "index_steps_on_transporter_id"
   end


### PR DESCRIPTION
- Display progress bar to optimize all action
- Extract daily quest link items to a dedicated dropdown menu
- Add feature to reset a daily quest
- Fix hardcoded drop_duration form value
- Add new status enum to handle conflict and impossible states
- Allow to drop back to backlog once all steps are assigned
- Redirect planning view to tomorrow if today missions are ended
- Add option to toggle password visibility on new session screen
- Refresh full transporter column on drop step to place to correct position
- Disable leaflet gesture on maps
- Bring back cluster marker groups on global map
