### PR TITLE
Add new setting option to auto open help panel by default

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -163,7 +163,7 @@ input.date, input.time, select.select {
 }
 
 .error, .error_notification {
-  @apply text-red-500 italic text-sm;
+  @apply block text-red-500 italic text-sm mt-2;
 }
 
 .error_notification {

--- a/app/models/settings_option.rb
+++ b/app/models/settings_option.rb
@@ -11,6 +11,7 @@ class SettingsOption
   attribute :enable_customers_map, :boolean, default: true
   attribute :enable_places_map, :boolean, default: true
   attribute :enable_transporters_map, :boolean, default: true
+  attribute :show_help, :boolean, default: true
 
   validates :map_refresh_interval, presence: true, inclusion: REFRESH_INTERVAL
   validates :theme, presence: true, inclusion: THEMES
@@ -27,4 +28,5 @@ class SettingsOption
   validates :enable_customers_map, allow_blank: false, inclusion: [true, false]
   validates :enable_places_map, allow_blank: false, inclusion: [true, false]
   validates :enable_transporters_map, allow_blank: false, inclusion: [true, false]
+  validates :show_help, allow_blank: false, inclusion: [true, false]
 end

--- a/app/views/customers/index.html.slim
+++ b/app/views/customers/index.html.slim
@@ -12,7 +12,7 @@ header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
     - else
       = link_to 'Clients archivés', customers_path(archived: true), class: 'btn-show'
 
-details.panel-info.mb-5
+details.panel-info.mb-5 open=options.show_help?
   summary.cursor-pointer Explications à lire
 
   .mt-3

--- a/app/views/daily_quests/edit.html.slim
+++ b/app/views/daily_quests/edit.html.slim
@@ -1,4 +1,4 @@
-details.panel-info.mb-5
+details.panel-info.mb-5 open=options.show_help?
   summary.cursor-pointer Explications à lire
 
   .mt-3

--- a/app/views/daily_quests/index.html.slim
+++ b/app/views/daily_quests/index.html.slim
@@ -61,7 +61,7 @@ header.mb-3
 
       = link_to "#{l(@daily_quest.started_on + 1.day)} >>", daily_quests_path(date: @daily_quest.started_on + 1.day), class: 'btn-back'
 
-details.panel-info.mb-3
+details.panel-info.mb-3 open=options.show_help?
   summary.cursor-pointer Explications à lire
 
   .mt-2

--- a/app/views/places/index.html.slim
+++ b/app/views/places/index.html.slim
@@ -3,7 +3,7 @@ header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
 
   = link_to 'Ajouter un lieu', new_place_path, class: 'btn-add'
 
-details.panel-info.mb-5
+details.panel-info.mb-5 open=options.show_help?
   summary.cursor-pointer Explications à lire
   p.mt-3 Les lieux représentent les différents endroits où les clients sont déposés. Ce peut-être un institut médical, un hôpital, une entreprise, ...
 

--- a/app/views/settings/_form.html.slim
+++ b/app/views/settings/_form.html.slim
@@ -17,7 +17,7 @@
                  include_blank: false
 
   = f.simple_fields_for :options, f.object.options do |ff|
-    .flex.flex-col.lg:flex-row.items-center.justify-between.gap-5
+    .flex.flex-col.lg:flex-row.items-center.justify-between.gap-5.mb-6
       = ff.input :map_refresh_interval,
                  collection: SettingsOption::REFRESH_INTERVAL,
                  include_blank: false,
@@ -29,14 +29,15 @@
       = ff.input :delta_loading,
                   wrapper_html: { class: 'mb-3' }
 
-    .flex.flex-col.lg:flex-row.items-center.justify-between.gap-5
       = ff.input :theme,
                  collection: settings_theme_select_options,
                  include_blank: false,
                  wrapper_html: { class: 'mb-3' }
 
+    .flex.flex-col.lg:flex-row.items-start.justify-between.gap-5
       = ff.input :enable_customers_map, as: :boolean
       = ff.input :enable_places_map, as: :boolean
       = ff.input :enable_transporters_map, as: :boolean
+      = ff.input :show_help, as: :boolean
 
   = f.button :submit, class: 'mt-6'

--- a/app/views/transporters/index.html.slim
+++ b/app/views/transporters/index.html.slim
@@ -3,7 +3,7 @@ header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
 
   = link_to 'Ajouter un chauffeur', new_transporter_path, class: 'btn-add'
 
-details.panel-info.mb-5
+details.panel-info.mb-5 open=options.show_help?
   summary.cursor-pointer Explications à lire
   .mt-3
     p.mb-3 Les chauffeurs à qui assigner les missions de transport sont à spécifier sur cette page.

--- a/app/views/vehicles/index.html.slim
+++ b/app/views/vehicles/index.html.slim
@@ -3,7 +3,7 @@ header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
 
   = link_to 'Ajouter un véhicule', new_vehicle_path, class: 'btn-add'
 
-details.panel-info.mb-5
+details.panel-info.mb-5 open=options.show_help?
   summary.cursor-pointer Explications à lire
 
   p.mt-3 Les différents véhicules sont à renseigner sur cette page. Les véhicules peuvent ensuite être associés à un chauffeur.

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -111,7 +111,7 @@ SimpleForm.setup do |config|
   # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
 
   # You can define the class to use on all labels. Default is nil.
-  config.label_class = 'inline-block mb-2'
+  config.label_class = 'inline-block'
 
   # You can define the default class to be used on forms. Can be overridden
   # with `html: { :class }`. Defaulting to none.

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -33,6 +33,7 @@ fr:
           enable_customers_map: Activer la carte clients ?
           enable_places_map: Activer la carte des lieux ?
           enable_transporters_map: Activer la carte des chauffeurs ?
+          show_help: Afficher les explications ?
 
     placeholders:
       customer:
@@ -97,3 +98,4 @@ fr:
           enable_customers_map: Si coché, une carte des clients sera affiché sur la page clients (n'affecte pas la carte globale)
           enable_places_map: Si coché, une carte des lieux sera affiché sur la page lieux (n'affecte pas la carte globale)
           enable_transporters_map: Si coché, une carte des chauffeurs sera affiché sur la page chauffeurs (n'affecte pas la carte globale)
+          show_help: Si coché, le bandeau d'aides et explications sera ouvert automatiquement sur les pages où il est présent. Autrement il sera fermé.


### PR DESCRIPTION
For now, help details are closed by default. For a better onboarding, this panel should be opened and toggled as closed from the setting options when usage is well understood.