### PR TITLE
Split `drop_duration` in `drop_duration_hours` and `drop_duration_minutes`

### DIFF
--- a/app/assets/stylesheets/components/form.css
+++ b/app/assets/stylesheets/components/form.css
@@ -44,3 +44,7 @@ textarea.text, input.file {
 input.boolean, input.check_boxes {
   @apply inline-block w-4 mr-1;
 }
+
+label.boolean, label.check_boxes {
+  @apply block;
+}

--- a/app/controllers/daily_quests/missions_controller.rb
+++ b/app/controllers/daily_quests/missions_controller.rb
@@ -69,8 +69,8 @@ module DailyQuests
 
     def mission_params
       params.require(:mission).permit(
-        :drop_time, :drop_duration, :round_trip,
-        :customer_id, :place_id
+        :drop_time, :round_trip, :drop_duration_hours,
+        :drop_duration_minutes, :customer_id, :place_id
       )
     end
 

--- a/app/helpers/missions_helper.rb
+++ b/app/helpers/missions_helper.rb
@@ -1,0 +1,13 @@
+module MissionsHelper
+  def value_for_drop_duration_hours(mission)
+    return mission.drop_duration_hours if mission.new_record?
+
+    mission.drop_duration / 60
+  end
+
+  def value_for_drop_duration_minutes(mission)
+    return mission.drop_duration_minutes if mission.new_record?
+
+    mission.drop_duration % 60
+  end
+end

--- a/app/views/daily_quests/missions/_form.html.slim
+++ b/app/views/daily_quests/missions/_form.html.slim
@@ -45,11 +45,21 @@
                   } \
                 }
 
-      = f.input :drop_duration,
-                wrapper_html: { \
-                  class: 'w-full mt-6', \
-                  data: { round_trip_target: 'durationInput' } \
-                }
+
+      div data-round-trip-target="durationInput"
+        = f.input :drop_duration_hours,
+                  as: :integer,
+                  wrapper_html: { class: 'w-full mt-5' },
+                  input_html: { \
+                    value: value_for_drop_duration_hours(f.object) \
+                  }
+        = f.input :drop_duration_minutes,
+                  as: :integer,
+                  include_blank: false,
+                  wrapper_html: { class: 'w-full mt-5' },
+                  input_html: { \
+                    value: value_for_drop_duration_minutes(f.object) \
+                  }
 
     = f.button :submit, 'Enregistrer', class: 'btn-add w-full'
 

--- a/app/views/daily_quests/missions/new.html.slim
+++ b/app/views/daily_quests/missions/new.html.slim
@@ -1,4 +1,5 @@
 h1 Nouvelle mission
 
 = turbo_frame_tag dom_id(@mission) do
-  = render 'form', mission: @mission
+  .lg:w-1/2.mx-auto
+    = render 'form', mission: @mission

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -50,7 +50,8 @@ fr:
         customer: Client
         place: Lieu
         drop_time: Heure à déposer au lieu de rendez-vous
-        drop_duration: Durée de la consultation
+        drop_duration_hours: Temps de consultation (partie heures)
+        drop_duration_minutes: Temps de consultation (partie minutes)
         round_trip: Trajet retour ?
 
       vehicle:

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -42,7 +42,8 @@ fr:
       customer:
         phone: "Format: 0123456789"
       mission:
-        drop_duration: Durée en minutes
+        drop_duration_hours: Partie heures
+        drop_duration_minutes: Partie minutes
 
     hints:
       company:
@@ -75,11 +76,12 @@ fr:
           label: "Note: Les adresses correspondantes à la valeur saisie dans le champs s'affichent et s'actualisent automatiquement."
         vehicle: Quel véhicule est assigné à ce transporteur ?
 
-      missions:
+      mission:
         customer: Le client à aller chercher
         place: Le lieu où le déposer
         drop_time: L'heure à laquelle chercher le client chez lui sera déterminée automatiquement par l'algorithme
-        drop_duration: Permet de déterminer automatiquement l'heure à laquelle le client doit être recherché (à spécifier en minutes)
+        drop_duration_hours: "Spécifiez la partie <strong>heures</strong> de la durée (exemple: pour <strong>1h30</strong> indiquez <strong>1</strong> dans ce champs et <strong>30</strong> dans le champ dédié aux <strong>minutes</strong>)"
+        drop_duration_minutes: "Spécifiez la partie <strong>minutes</strong> de la durée (voir l'exemple précédent)"
         round_trip: Cocher la case si un trajet retour est à prévoir pour cette mission
 
       step:


### PR DESCRIPTION
Instead of having to calculate a duration in minutes, replace the single total minutes field by two: one for the hours part, and the other for the minutes part.

<img width="765" alt="Capture d’écran 2023-10-31 à 19 00 38" src="https://github.com/La-Voix-du-chat-artiste/mobilia/assets/5428510/ac2ce22c-afea-48ff-87c7-5de5b4dfdd8f">
